### PR TITLE
Fix Android WebView geolocation permissions

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -8,6 +8,8 @@
     <uses-permission android:name="android.permission.VIBRATE" />
     <uses-permission android:name="android.permission.WAKE_LOCK" />
     <uses-permission android:name="android.permission.USE_FULL_SCREEN_INTENT" />  
+    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION"/>
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"/>
     
     <queries>
         <package android:name="com.kakao.talk" />

--- a/lib/views/taxiView.dart
+++ b/lib/views/taxiView.dart
@@ -507,6 +507,7 @@ class TaxiView extends HookWidget {
                 initialOptions: InAppWebViewGroupOptions(
                     crossPlatform: InAppWebViewOptions(
                         useShouldOverrideUrlLoading: true,
+                        enableViewportScale: true,
                         applicationNameForUserAgent: "taxi-app-webview/" +
                             (Platform.isAndroid ? "android" : "ios"),
                         resourceCustomSchemes: [

--- a/lib/views/taxiView.dart
+++ b/lib/views/taxiView.dart
@@ -520,7 +520,8 @@ class TaxiView extends HookWidget {
                     android: AndroidInAppWebViewOptions(
                         useHybridComposition: true,
                         overScrollMode:
-                            AndroidOverScrollMode.OVER_SCROLL_NEVER),
+                            AndroidOverScrollMode.OVER_SCROLL_NEVER,
+                        geolocationEnabled: true),
                     ios: IOSInAppWebViewOptions(disallowOverScroll: true)),
                 // initialUrlRequest: URLRequest(url: Uri.parse(address)),
                 shouldOverrideUrlLoading: (controller, navigationAction) async {
@@ -610,6 +611,22 @@ class TaxiView extends HookWidget {
                           openAppSettings();
                           Fluttertoast.showToast(
                               msg: "알림 권한을 허용해주세요.",
+                              toastLength: Toast.LENGTH_SHORT,
+                              textColor: toastTextColor,
+                              backgroundColor: toastBackgroundColor);
+                          return false;
+                        }
+                      });
+
+                  _controller.value?.addJavaScriptHandler(
+                      handlerName: "try_location",
+                      callback: (args) async {
+                        if (await Permission.locationWhenInUse.isGranted) {
+                          return true;
+                        } else {
+                          openAppSettings();
+                          Fluttertoast.showToast(
+                              msg: "위치 권한을 허용해주세요.",
                               toastLength: Toast.LENGTH_SHORT,
                               textColor: toastTextColor,
                               backgroundColor: toastBackgroundColor);

--- a/lib/views/taxiView.dart
+++ b/lib/views/taxiView.dart
@@ -846,6 +846,23 @@ class TaxiView extends HookWidget {
                   if (!isServerError.value) {
                     isLoaded.value = true;
                   }
+                },
+                androidOnPermissionRequest:
+                    (controller, origin, resources) async {
+                  if (resources.contains("geolocation")) {
+                    var status = await Permission.location.request();
+                    if (!status.isGranted) {
+                      openAppSettings();
+                    }
+                  }
+                  return PermissionRequestResponse(
+                      resources: resources,
+                      action: PermissionRequestResponseAction.GRANT);
+                },
+                androidOnGeolocationPermissionsShowPrompt:
+                    (InAppWebViewController controller, String origin) async {
+                  return GeolocationPermissionShowPromptResponse(
+                      origin: origin, allow: true, retain: true);
                 }),
           )),
       isTimerUp.value && isLoaded.value && isFcmInit.value


### PR DESCRIPTION
## Summary
- enable Android geolocation in the in-app webview
- add Android location permissions required for WebView geolocation prompts
- expose a `try_location` JavaScript handler so the web app can guide users to enable location permission

## Why
Issue #96 requests geolocation support in the Taxi WebView for location-based flows. There is an older draft PR with broader dependency / SDK upgrades, but this PR intentionally keeps the change set minimal and low-risk by only taking the Android WebView geolocation pieces that are required.

## Testing
- `git diff --check`
- Manual code inspection of `AndroidManifest.xml` and `lib/views/taxiView.dart`

## Notes
- I could not run `flutter` / `dart` commands in the current environment because those binaries are not installed in this shell, so no app build/analyze output is included here.
- This PR avoids the broader dependency upgrades from the existing draft PR and focuses on the smallest viable Android WebView fix.